### PR TITLE
fix(deploy-to-ecs): opt-in to use buildkit for docker builds

### DIFF
--- a/deploy-to-ecs/action.yml
+++ b/deploy-to-ecs/action.yml
@@ -49,7 +49,7 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr_repository }}
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build --target=production -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+        DOCKER_BUILDKIT=1 docker build --target=production -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
         echo "::set-output name=tagged_image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         echo "::set-output name=latest_image::$ECR_REGISTRY/$ECR_REPOSITORY:latest"
 


### PR DESCRIPTION
Opting in to use buildkit with Docker means a lot: https://docs.docker.com/develop/develop-images/build_enhancements/

Most important is that not all stages are run upon build with a `--target`

I guess most of our local environment are using buildkit currently so it was quite hard to spot.