### PR TITLE
fix: update actions to use node16

### DIFF
--- a/configure-aws/action.yml
+++ b/configure-aws/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}

--- a/deploy-ecs-service/action.yml
+++ b/deploy-ecs-service/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS
-      uses: Heja/actions/configure-aws@v1.1
+      uses: Heja/actions/configure-aws@v2
       with:
         aws_access_key_id: ${{ inputs.aws_access_key_id }}
         aws_secret_access_key: ${{ inputs.aws_secret_access_key }}

--- a/deploy-ecs-service/action.yml
+++ b/deploy-ecs-service/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS
-      uses: Heja/actions/configure-aws@v2
+      uses: Heja/actions/configure-aws@v3
       with:
         aws_access_key_id: ${{ inputs.aws_access_key_id }}
         aws_secret_access_key: ${{ inputs.aws_secret_access_key }}

--- a/deploy-to-ecs/action.yml
+++ b/deploy-to-ecs/action.yml
@@ -34,7 +34,7 @@ runs:
       uses: actions/checkout@v3
 
     - name: Configure AWS credentials
-      uses: Heja/actions/configure-aws@v2
+      uses: Heja/actions/configure-aws@v3
       with:
         aws_access_key_id: ${{ inputs.aws_access_key_id }}
         aws_secret_access_key: ${{ inputs.aws_secret_access_key }}
@@ -68,7 +68,7 @@ runs:
         docker push $LATEST_IMAGE
 
     - name: Deploy task definition
-      uses: Heja/actions/deploy-ecs-service@v1.1
+      uses: Heja/actions/deploy-ecs-service@v3
       with:
         ecs_task_family: ${{ inputs.ecs_task_family }}
         ecs_service: ${{ inputs.ecs_service }}

--- a/deploy-to-ecs/action.yml
+++ b/deploy-to-ecs/action.yml
@@ -31,10 +31,10 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure AWS credentials
-      uses: Heja/actions/configure-aws@v1.1
+      uses: Heja/actions/configure-aws@v2
       with:
         aws_access_key_id: ${{ inputs.aws_access_key_id }}
         aws_secret_access_key: ${{ inputs.aws_secret_access_key }}

--- a/format-check/action.yml
+++ b/format-check/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     

--- a/lint-check/action.yml
+++ b/lint-check/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     

--- a/tag-release/action.yml
+++ b/tag-release/action.yml
@@ -17,7 +17,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checout code with tags
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0 # needed to get tags
 


### PR DESCRIPTION
Github Actions are complaining about actions using node12 so this updates to node16 and adds the next version of the actions to be used in repos.